### PR TITLE
fix compatibility with jfryman/nginx v0.2.7

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,7 +7,7 @@ mod 'jhoblitt/sysstat'
 
 mod 'maestrodev/wget', '~> 1.7.0'
 mod 'puppetlabs/firewall', '~> 1.5.0'
-mod 'jfryman/nginx', '~> 0.2.6'
+mod 'jfryman/nginx', '~> 0.2.7'
 mod 'jfryman/selinux', '~> 0.2.3'
 mod 'saz/timezone', '~> 3.3.0'
 mod 'puppetlabs/ntp', '~> 3.3.0'
@@ -30,7 +30,11 @@ mod 'lsst/lsststack',
 
 mod 'jhoblitt/ganglia', '~> 2.0'
 mod 'mayflower/php', '~> 3.2'
-mod 'puppetlabs/concat', '~> 1.2'
+# https://github.com/puppetlabs/puppetlabs-concat/pull/361
+mod 'puppetlabs/concat',
+  :git => 'https://github.com/puppetlabs/puppetlabs-concat.git',
+  :ref => 'fd4f1e2d46a86f1659da420f4ce042882d38e021'
+
 mod 'stankevich/python', '~> 1.9'
 
 mod 'lsst/jenkins_demo', :path => './jenkins_demo'

--- a/jenkins_demo/manifests/profile/master.pp
+++ b/jenkins_demo/manifests/profile/master.pp
@@ -160,23 +160,41 @@ class jenkins_demo::profile::master {
 
   if $enable_ssl {
     file { $private_dir:
-      ensure => directory,
-      mode   => '0700',
+      ensure   => directory,
+      mode     => '0750',
+      selrange => 's0',
+      selrole  => 'object_r',
+      seltype  => 'httpd_config_t',
+      seluser  => 'system_u',
     }
 
     exec { 'openssl dhparam -out dhparam.pem 2048':
       path    => ['/usr/bin'],
       cwd     => $private_dir,
-      umask   => '0400',
+      umask   => '0433',
       creates => $ssl_dhparam_path,
+    } ->
+    file { $ssl_dhparam_path:
+      ensure   => file,
+      mode     => '0400',
+      selrange => 's0',
+      selrole  => 'object_r',
+      seltype  => 'httpd_config_t',
+      seluser  => 'system_u',
+      replace  => false,
+      backup   => false,
     }
 
     # note that nginx needs the signed cert and the CA chain in the same file
     concat { $ssl_cert_path:
-      ensure => present,
-      mode   => '0444',
-      backup => false,
-      before => Class['::nginx'],
+      ensure   => present,
+      mode     => '0444',
+      selrange => 's0',
+      selrole  => 'object_r',
+      seltype  => 'httpd_config_t',
+      seluser  => 'system_u',
+      backup   => false,
+      before   => Class['::nginx'],
     }
     concat::fragment { 'public - signed cert':
       target  => $ssl_cert_path,
@@ -192,6 +210,10 @@ class jenkins_demo::profile::master {
     file { $ssl_key_path:
       ensure    => file,
       mode      => '0400',
+      selrange  => 's0',
+      selrole   => 'object_r',
+      seltype   => 'httpd_config_t',
+      seluser   => 'system_u',
       content   => $ssl_key,
       backup    => false,
       show_diff => false,
@@ -199,10 +221,14 @@ class jenkins_demo::profile::master {
     }
 
     concat { $ssl_root_chain_path:
-      ensure => present,
-      mode   => '0444',
-      backup => false,
-      before => Class['::nginx'],
+      ensure   => present,
+      mode     => '0444',
+      selrange => 's0',
+      selrole  => 'object_r',
+      seltype  => 'httpd_config_t',
+      seluser  => 'system_u',
+      backup   => false,
+      before   => Class['::nginx'],
     }
     concat::fragment { 'root-chain - chain cert':
       target  => $ssl_root_chain_path,


### PR DESCRIPTION
v0.2.7 no long makes copies of ssl related files into the `/etc/nginx`
directory.  This means that when selinux is enabled, the files passed
into the `nginx::resource::vhost` need to have the correct selinux
labels to be read by a http server.