### PR TITLE
split qserv_distrib & dax_webserv out of stack-os-matrix

### DIFF
--- a/jenkins_demo/manifests/profile/master.pp
+++ b/jenkins_demo/manifests/profile/master.pp
@@ -32,6 +32,14 @@ class jenkins_demo::profile::master {
     config => template("${module_name}/jobs/stack-os-matrix/config.xml"),
   }
 
+  jenkins::job { 'qserv-os-matrix':
+    config => template("${module_name}/jobs/qserv-os-matrix/config.xml"),
+  }
+
+  jenkins::job { 'dax_webserv-os-matrix':
+    config => template("${module_name}/jobs/dax_webserv-os-matrix/config.xml"),
+  }
+
   $jenkins_ebs_snapshot = hiera('jenkins::jobs::jenkins_ebs_snapshot', undef)
   if $jenkins_ebs_snapshot {
     class { 'python' :

--- a/jenkins_demo/templates/jobs/dax_webserv-os-matrix/config.xml
+++ b/jenkins_demo/templates/jobs/dax_webserv-os-matrix/config.xml
@@ -14,12 +14,12 @@
         <hudson.model.StringParameterDefinition>
           <name>PRODUCT</name>
           <description>Whitespace delimited list of EUPS products to build.</description>
-          <defaultValue>lsst_sims lsst_distrib</defaultValue>
+          <defaultValue>dax_webserv</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>SKIP_DEMO</name>
           <description>Do not run the demo after all packages have completed building.</description>
-          <defaultValue>false</defaultValue>
+          <defaultValue>true</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>NO_FETCH</name>

--- a/jenkins_demo/templates/jobs/qserv-os-matrix/config.xml
+++ b/jenkins_demo/templates/jobs/qserv-os-matrix/config.xml
@@ -14,12 +14,12 @@
         <hudson.model.StringParameterDefinition>
           <name>PRODUCT</name>
           <description>Whitespace delimited list of EUPS products to build.</description>
-          <defaultValue>lsst_sims lsst_distrib</defaultValue>
+          <defaultValue>qserv_distrib</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>SKIP_DEMO</name>
           <description>Do not run the demo after all packages have completed building.</description>
-          <defaultValue>false</defaultValue>
+          <defaultValue>true</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>NO_FETCH</name>


### PR DESCRIPTION
Into new jobs named qserv-os-matrix and dax_webserv-os-matrix which are
duplicates of stack-os-matrix but with the "demo" disabled by default.

Note that webserv had not yet been renamed to dax_webserv in
stack-os-matrix.