### PR TITLE
Only use --product if a product has been specified

### DIFF
--- a/jenkins_demo/templates/jobs/dax_webserv-os-matrix/config.xml
+++ b/jenkins_demo/templates/jobs/dax_webserv-os-matrix/config.xml
@@ -67,8 +67,12 @@ fi
 
 ARGS+=(&apos;--build_number&apos;)
 ARGS+=(&quot;$BUILD_NUMBER&quot;)
-ARGS+=(&apos;--product&apos;)
-ARGS+=(&quot;$PRODUCT&quot;)
+
+if [ ! -z &quot;$PRODUCT&quot; ]; then
+  ARGS+=(&apos;--product&apos;)
+  ARGS+=(&quot;$PRODUCT&quot;)
+fi
+
 ARGS+=(&apos;--skip_docs&apos;)
 ARGS+=(&apos;--print-fail&apos;)
 ARGS+=(&apos;--color&apos;)

--- a/jenkins_demo/templates/jobs/qserv-os-matrix/config.xml
+++ b/jenkins_demo/templates/jobs/qserv-os-matrix/config.xml
@@ -67,8 +67,12 @@ fi
 
 ARGS+=(&apos;--build_number&apos;)
 ARGS+=(&quot;$BUILD_NUMBER&quot;)
-ARGS+=(&apos;--product&apos;)
-ARGS+=(&quot;$PRODUCT&quot;)
+
+if [ ! -z &quot;$PRODUCT&quot; ]; then
+  ARGS+=(&apos;--product&apos;)
+  ARGS+=(&quot;$PRODUCT&quot;)
+fi
+
 ARGS+=(&apos;--skip_docs&apos;)
 ARGS+=(&apos;--print-fail&apos;)
 ARGS+=(&apos;--color&apos;)

--- a/jenkins_demo/templates/jobs/stack-os-matrix/config.xml
+++ b/jenkins_demo/templates/jobs/stack-os-matrix/config.xml
@@ -67,8 +67,12 @@ fi
 
 ARGS+=(&apos;--build_number&apos;)
 ARGS+=(&quot;$BUILD_NUMBER&quot;)
-ARGS+=(&apos;--product&apos;)
-ARGS+=(&quot;$PRODUCT&quot;)
+
+if [ ! -z &quot;$PRODUCT&quot; ]; then
+  ARGS+=(&apos;--product&apos;)
+  ARGS+=(&quot;$PRODUCT&quot;)
+fi
+
 ARGS+=(&apos;--skip_docs&apos;)
 ARGS+=(&apos;--print-fail&apos;)
 ARGS+=(&apos;--color&apos;)


### PR DESCRIPTION
Experimental patches to fix the running of CI without an explicit product.

I changed all three copies of the code. Not sure if that was really needed.