### PR TITLE
bump jenkins version to 2.7.4

### DIFF
--- a/hieradata/role/master.eyaml
+++ b/hieradata/role/master.eyaml
@@ -1,7 +1,7 @@
 ---
 classes:
   - jenkins_demo::role::master
-jenkins::version: '2.7.2-1.1'
+jenkins::version: '2.7.4-1.1'
 jenkins::lts: true
 jenkins::master::version: '2.2'
 jenkins::config_hash:


### PR DESCRIPTION
To resolve master<->slave communication issues.  Per the [LTS
Changelog](https://jenkins.io/changelog-stable/), 2.7.3 disabled the new
`JNLP3` protocol, which was the reportedly the cause of widespread
communication issues.