### PR TITLE
Rename bokeh app and removed restart of bokeh server each 300s

### DIFF
--- a/jenkins_demo/templates/squash/squash-bokeh@.service.epp
+++ b/jenkins_demo/templates/squash/squash-bokeh@.service.epp
@@ -12,10 +12,9 @@ Environment="PATH=/opt/apps/qa-dashboard/venv/bin:$PATH"
 Environment="SQUASH_API_URL=https://<%= $squash_fqdn %>/dashboard/api/"
 Environment="SQUASH_BASE_URL=https://<%= $squash_fqdn %>/"
 WorkingDirectory=/opt/apps/qa-dashboard/squash
-ExecStart=/usr/bin/scl enable rh-python35 -- /opt/apps/qa-dashboard/venv/bin/bokeh serve --log-level=info --port=%i --host=<%= $bokeh_fqdn %> --allow-websocket-origin=<%= $squash_fqdn %> --use-xheaders dashboard/viz/regression dashboard/viz/AMx dashboard/viz/PAx
+ExecStart=/usr/bin/scl enable rh-python35 -- /opt/apps/qa-dashboard/venv/bin/bokeh serve --log-level=info --port=%i --host=<%= $bokeh_fqdn %> --allow-websocket-origin=<%= $squash_fqdn %> --use-xheaders dashboard/viz/monitor dashboard/viz/AMx dashboard/viz/PAx
 Restart=always
 StandardError=syslog
-WatchdogSec=300
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The stability of SQuaSH, in particular of the bokeh apps has been improved in the DM-9651 epic.
It is being verified on my sandbox instance https://angelo-squash-squash.lsst.codes/ after removing the automatic 300s restart of the bokeh server added previously to mitigate the instability problems.

More info at DM-9727.