### PR TITLE
bump jenkins matrix-project plugin to 1.10

### DIFF
--- a/hieradata/role/master.eyaml
+++ b/hieradata/role/master.eyaml
@@ -27,7 +27,7 @@ jenkins::plugin_hash:
   junit:
     version: '1.18'
   matrix-project:
-    version: '1.7.1'
+    version: '1.10'
   # matrix-project deps
   script-security:
     version: '1.24'


### PR DESCRIPTION
bump jenkins matrix-project plugin to 1.10
    
Fix lost, inaccessible, and/or incorrect links between a parent build and its matrix sub-configurations.

Primary fix: https://github.com/jenkinsci/matrix-project-plugin/pull/41