### PR TITLE
remove centos/docker labels from snowflake nodes

### DIFF
--- a/hieradata/role/snowflake.yaml
+++ b/hieradata/role/snowflake.yaml
@@ -3,7 +3,10 @@ classes:
   - jenkins_demo::role::slave
   - rvm
 jenkins_demo::profile::slave::slave_mode: exclusive
+# prevent jobs tied to "docker" or "centos-7" from running on this node
+jenkins_demo::profile::slave::use_default_labels: false
 jenkins_demo::profile::slave::labels:
+  - "%{::hostname}"
   - snowflake
 lsststack::install_convenience: true
 rvm::system_rubies:


### PR DESCRIPTION
To prevent jobs bound to these labels from running on a snowflake node.