### PR TITLE
fix ruby 2.2 openssl 1.0.2 link errors

### DIFF
--- a/hieradata/common.eyaml
+++ b/hieradata/common.eyaml
@@ -116,3 +116,18 @@ jenkins::slave::ui_pass: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBH
 # name and the pipeline script hangs forever.
 jenkins::slave::disable_clients_unique_id: true
 jenkins::slave::delete_existing_clients: true
+rvm::version: '1.29.3'
+rvm::system_rubies:
+  'ruby-2.2':
+    ensure: absent
+  'ruby-2.4.2':
+    default_use: true
+    build_opts:
+      - '--disable-binary'
+rvm::system_users:
+  - jenkins-slave
+rvm::rvm_gems:
+  'bundler':
+    name: 'bundler'
+    ruby_version: 'ruby-2.4.2'
+    ensure: '1.13.6'

--- a/hieradata/role/slave.yaml
+++ b/hieradata/role/slave.yaml
@@ -3,20 +3,5 @@ classes:
   - jenkins_demo::role::slave
   - rvm
 lsststack::install_convenience: true
-rvm::version: '1.29.3'
-rvm::system_rubies:
-  'ruby-2.2':
-    ensure: absent
-  'ruby-2.4.2':
-    default_use: true
-    build_opts:
-      - '--disable-binary'
-rvm::system_users:
-  - jenkins-slave
-rvm::rvm_gems:
-  'bundler':
-    name: 'bundler'
-    ruby_version: 'ruby-2.4.2'
-    ensure: '1.13.6'
 docker::version: '1.12.3'
 docker::storage_driver: devicemapper

--- a/hieradata/role/slave.yaml
+++ b/hieradata/role/slave.yaml
@@ -3,6 +3,7 @@ classes:
   - jenkins_demo::role::slave
   - rvm
 lsststack::install_convenience: true
+rvm::version: '1.29.3'
 rvm::system_rubies:
   'ruby-2.2':
     default_use: true

--- a/hieradata/role/slave.yaml
+++ b/hieradata/role/slave.yaml
@@ -6,13 +6,17 @@ lsststack::install_convenience: true
 rvm::version: '1.29.3'
 rvm::system_rubies:
   'ruby-2.2':
+    ensure: absent
+  'ruby-2.4.2':
     default_use: true
+    build_opts:
+      - '--disable-binary'
 rvm::system_users:
   - jenkins-slave
 rvm::rvm_gems:
   'bundler':
     name: 'bundler'
-    ruby_version: 'ruby-2.2'
+    ruby_version: 'ruby-2.4.2'
     ensure: '1.13.6'
 docker::version: '1.12.3'
 docker::storage_driver: devicemapper

--- a/hieradata/role/snowflake.yaml
+++ b/hieradata/role/snowflake.yaml
@@ -9,15 +9,5 @@ jenkins_demo::profile::slave::labels:
   - "%{::hostname}"
   - snowflake
 lsststack::install_convenience: true
-rvm::system_rubies:
-  'ruby-2.2':
-    default_use: true
-rvm::system_users:
-  - jenkins-slave
-rvm::rvm_gems:
-  'bundler':
-    name: 'bundler'
-    ruby_version: 'ruby-2.2'
-    ensure: '1.13.6'
 docker::version: '1.12.3'
 docker::storage_driver: devicemapper

--- a/jenkins_demo/manifests/role/slave.pp
+++ b/jenkins_demo/manifests/role/slave.pp
@@ -4,6 +4,4 @@ class jenkins_demo::role::slave {
   include ::jenkins_demo::profile::slave
   class { 'selinux': mode => 'disabled' }
   include ::jenkins_demo::profile::devtoolset_3
-  include ::jenkins_demo::profile::devtoolset_4
-  include ::jenkins_demo::profile::devtoolset_6
 }


### PR DESCRIPTION
```
==> el7-6: Error: /Stage[main]/Ruby::Dev/Package[bundler]/ensure: change from absent to latest failed: Could not update: Execution of '/usr/local/rvm/rubies/ruby-2.2.7/bin/gem install --no-rdoc --no-ri bundler' returned 1: Error loading RubyGems plugin "/usr/local/rvm/gems/ruby-2.2.7@global/gems/executable-hooks-1.3.2/lib/rubygems_plugin.rb": /lib64/libcrypto.so.10: version `OPENSSL_1.0.2' not found (required by /usr/local/rvm/rubies/ruby-2.2.7/lib/ruby/2.2.0/x86_64-linux/openssl.so) - /usr/local/rvm/rubies/ruby-2.2.7/lib/ruby/2.2.0/x86_64-linux/openssl.so (LoadError)
==> el7-6: Error loading RubyGems plugin "/usr/local/rvm/gems/ruby-2.2.7@global/gems/gem-wrappers-1.3.2/lib/rubygems_plugin.rb": /lib64/libcrypto.so.10: version `OPENSSL_1.0.2' not found (required by /usr/local/rvm/rubies/ruby-2.2.7/lib/ruby/2.2.0/x86_64-linux/openssl.so) - /usr/local/rvm/rubies/ruby-2.2.7/lib/ruby/2.2.0/x86_64-linux/openssl.so (LoadError)
==> el7-6: ERROR:  Loading command: install (LoadError)
==> el7-6: 	/lib64/libcrypto.so.10: version `OPENSSL_1.0.2' not found (required by /usr/local/rvm/rubies/ruby-2.2.7/lib/ruby/2.2.0/x86_64-linux/openssl.so) - /usr/local/rvm/rubies/ruby-2.2.7/lib/ruby/2.2.0/x86_64-linux/openssl.so
==> el7-6: ERROR:  While executing gem ... (NoMethodError)
==> el7-6:     undefined method `invoke_with_build_args' for nil:NilClass
```