### PR TITLE
bump el7 kernel to 3.10.0-693.11.1.el7.x86_64

### DIFF
--- a/hieradata/os/RedHat/7.yaml
+++ b/hieradata/os/RedHat/7.yaml
@@ -1,5 +1,5 @@
 ---
 packages:
   - 'cmake-2.8.12.2-2.el7.x86_64'
-jenkins_demo::profile::kernel::version: '3.10.0-693.5.2.el7.x86_64'
+jenkins_demo::profile::kernel::version: '3.10.0-693.11.1.el7.x86_64'
 java::package: 'java-1.8.0-openjdk-devel-1.8.0.151-1.b12.el7_4.x86_64'


### PR DESCRIPTION
There are changelog entries that refer to XFS fixes.  This may be
related to the dockerd / XFS timeout errors we are seeing on ec2.