### PR TITLE
fix duplicate declaration of jenkins::config_hash

### DIFF
--- a/hieradata/role/master.eyaml
+++ b/hieradata/role/master.eyaml
@@ -4,9 +4,17 @@ classes:
 jenkins::version: '2.89.3-1.1'
 jenkins::lts: true
 jenkins::master::version: '3.8'
+jenkins::config_firewall: false
+jenkins::cli: true
 jenkins::config_hash:
   JENKINS_JAVA_OPTIONS:
     value: '-Dhudson.security.csrf.requestfield=Jenkins-crumb -Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -Dhudson.slaves.WorkspaceList=_'
+  JENKINS_LISTEN_ADDRESS:
+    value: ''
+  JENKINS_HTTPS_PORT:
+    value: ''
+  JENKINS_AJP_PORT:
+    value: '-1'
 jenkins::default_plugins: []
 jenkins::purge_plugins: true
 # XXX there is no recursive plugin dep resolution; so we have to do this by

--- a/jenkins_demo/manifests/profile/master.pp
+++ b/jenkins_demo/manifests/profile/master.pp
@@ -4,21 +4,10 @@ class jenkins_demo::profile::master(
 ) {
   include ::wget # needed by jenkins
   include ::nginx
+  include ::jenkins
+  include ::jenkins::master # <- I am a swarm master
 
   Class['::wget'] -> Class['::jenkins']
-  # lint:ignore:arrow_alignment
-  class { 'jenkins':
-    configure_firewall => false,
-    cli                => true,
-    #executors          => 0,
-    config_hash        => {
-      'JENKINS_LISTEN_ADDRESS' => { 'value' => '' },
-      'JENKINS_HTTPS_PORT'     => { 'value' => '' },
-      'JENKINS_AJP_PORT'       => { 'value' => '-1' },
-    },
-  }
-  # lint:endignore
-  include ::jenkins::master # <- I am a swarm master
 
   jenkins_num_executors{ '0': ensure => present }
   jenkins_slaveagent_port{ '55555': ensure => present }


### PR DESCRIPTION
The config_hash parameter was being both declared in puppet code and via
hiera resulting in the hiera version being ignored.