### PR TITLE
add xfs pquota support to {master,agent} roles

### DIFF
--- a/jenkins_demo/manifests/profile/kernel/pquota.pp
+++ b/jenkins_demo/manifests/profile/kernel/pquota.pp
@@ -1,0 +1,10 @@
+class jenkins_demo::profile::kernel::pquota() {
+  kernel_parameter { 'rootflags=pquota':
+    ensure => present,
+  } ~>
+  reboot { 'rootfs xfs pquota':
+    apply   => finished,
+    message => 'enable rootfs xfs pquota',
+    when    => refreshed,
+  }
+}

--- a/jenkins_demo/manifests/role/agent.pp
+++ b/jenkins_demo/manifests/role/agent.pp
@@ -5,4 +5,5 @@ class jenkins_demo::role::agent {
   class { 'selinux': mode => 'disabled' }
   include ::jenkins_demo::profile::kernel
   include ::jenkins_demo::profile::kernel::nopti
+  include ::jenkins_demo::profile::kernel::pquota
 }

--- a/jenkins_demo/manifests/role/master.pp
+++ b/jenkins_demo/manifests/role/master.pp
@@ -10,4 +10,5 @@ class jenkins_demo::role::master {
   include ::jenkins_demo::profile::jenkins::agent
   class { 'selinux': mode => 'enforcing' }
   include ::jenkins_demo::profile::kernel
+  include ::jenkins_demo::profile::kernel::pquota
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -96,7 +96,7 @@ resource "aws_security_group" "jenkins-demo-ssh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["140.252.0.0/16", "67.212.196.0/24"]
+    cidr_blocks = ["140.252.0.0/16", "64.119.41.0/24"]
   }
 
   tags {


### PR DESCRIPTION
Note that the `pquota` flag is discussed in `docker-run(1)` but is absent from https://docs.docker.com/storage/storagedriver/overlayfs-driver/#prerequisites