### PR TITLE
update default centos AMI + redhat 7 package versions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 required_plugins = %w[
-  vagrant-librarian-puppet
   vagrant-puppet-install
   vagrant-aws
 ]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,8 +55,8 @@ def ssh_private_key_path
 end
 
 def master_ami
-  # centos 1801_11 (2018-01-14)
-  ENV['MASTER_AMI'] || 'ami-4bf3d731'
+  # us-east-1 centos 1804_2 (2018-05-16)
+  ENV['MASTER_AMI'] || 'ami-d5bf2caa'
 end
 
 def centos7_ami

--- a/hieradata/os/RedHat/7.yaml
+++ b/hieradata/os/RedHat/7.yaml
@@ -9,7 +9,7 @@ packages:
   - 'tmux'
   - 'tree'
   - 'vim'
-jenkins_demo::profile::kernel::version: '3.10.0-693.17.1.el7.x86_64'
+jenkins_demo::profile::kernel::version: '3.10.0-862.3.2.el7.x86_64'
 java::package: 'java-1.8.0-openjdk-devel-1.8.0.171-8.b10.el7_5'
 files:
   '/etc/profile.d/rh-git29.sh':

--- a/hieradata/os/RedHat/7.yaml
+++ b/hieradata/os/RedHat/7.yaml
@@ -3,7 +3,6 @@ packages:
   - 'ack'
   - 'centos-release-scl'
   - 'git'
-  - 'java-1.8.0-openjdk-devel-1.8.0.151-1.b12.el7_4.x86_64'
   - 'rh-git29'
   - 'scl-utils'
   - 'screen'
@@ -11,7 +10,7 @@ packages:
   - 'tree'
   - 'vim'
 jenkins_demo::profile::kernel::version: '3.10.0-693.17.1.el7.x86_64'
-java::package: 'java-1.8.0-openjdk-1.8.0.151-1.b12.el7_4.x86_64'
+java::package: 'java-1.8.0-openjdk-devel-1.8.0.171-8.b10.el7_5'
 files:
   '/etc/profile.d/rh-git29.sh':
     content: |

--- a/hieradata/os/RedHat/7.yaml
+++ b/hieradata/os/RedHat/7.yaml
@@ -2,7 +2,6 @@
 packages:
   - 'ack'
   - 'centos-release-scl'
-  - 'cmake-2.8.12.2-2.el7.x86_64'
   - 'git'
   - 'java-1.8.0-openjdk-devel-1.8.0.151-1.b12.el7_4.x86_64'
   - 'rh-git29'

--- a/hieradata/os/RedHat/7.yaml
+++ b/hieradata/os/RedHat/7.yaml
@@ -1,15 +1,15 @@
 ---
 packages:
+  - 'centos-release-scl'
   - 'cmake-2.8.12.2-2.el7.x86_64'
+  - 'git'
+  - 'java-1.8.0-openjdk-devel-1.8.0.151-1.b12.el7_4.x86_64'
+  - 'rh-git29'
+  - 'scl-utils'
   - 'screen'
   - 'tmux'
   - 'tree'
   - 'vim'
-  - 'java-1.8.0-openjdk-devel-1.8.0.151-1.b12.el7_4.x86_64'
-  - 'centos-release-scl'
-  - 'scl-utils'
-  - 'rh-git29'
-  - 'git'
 jenkins_demo::profile::kernel::version: '3.10.0-693.17.1.el7.x86_64'
 java::package: 'java-1.8.0-openjdk-1.8.0.151-1.b12.el7_4.x86_64'
 files:

--- a/hieradata/os/RedHat/7.yaml
+++ b/hieradata/os/RedHat/7.yaml
@@ -1,5 +1,6 @@
 ---
 packages:
+  - 'ack'
   - 'centos-release-scl'
   - 'cmake-2.8.12.2-2.el7.x86_64'
   - 'git'

--- a/jenkins_demo/manifests/profile/jenkins/agent.pp
+++ b/jenkins_demo/manifests/profile/jenkins/agent.pp
@@ -44,7 +44,6 @@ class jenkins_demo::profile::jenkins::agent(
     $real_labels = $labels
   }
 
-  notice($real_labels)
   class { 'jenkins::slave':
     masterurl    => 'http://jenkins-master:8080',
     slave_name   => $::hostname,


### PR DESCRIPTION
Previous pinned package versions were no longer available from public centos
mirrors.