### PR TITLE
bump docker to 18.03.1.ce

### DIFF
--- a/hieradata/common.eyaml
+++ b/hieradata/common.eyaml
@@ -131,6 +131,6 @@ rvm::rvm_gems:
     name: 'bundler'
     ruby_version: 'ruby-2.4.2'
     ensure: '1.13.6'
-docker::version: '17.12.1.ce'
+docker::version: '18.03.1.ce'
 timezone::timezone: 'US/Pacific'
 tuned::profile: 'virtual-host'


### PR DESCRIPTION
Updating to tracking the current release -- no major bugfixes:

https://docs.docker.com/release-notes/docker-ce/#stable-releases