### PR TITLE
shorten fsroot/workspace paths

### DIFF
--- a/hieradata/role/master.eyaml
+++ b/hieradata/role/master.eyaml
@@ -9,7 +9,7 @@ jenkins::config_firewall: false
 jenkins::cli: true
 jenkins::config_hash:
   JENKINS_JAVA_OPTIONS:
-    value: '-Dhudson.security.csrf.requestfield=Jenkins-crumb -Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -Dhudson.slaves.WorkspaceList=_'
+    value: '-Dhudson.security.csrf.requestfield=Jenkins-crumb -Djava.awt.headless=true -Djenkins.install.runSetupWizard=false -Dhudson.slaves.WorkspaceList=_ -Dhudson.model.Slave.workspaceRoot=ws'
   JENKINS_LISTEN_ADDRESS:
     value: ''
   JENKINS_HTTPS_PORT:

--- a/jenkins_demo/manifests/profile/jenkins/agent.pp
+++ b/jenkins_demo/manifests/profile/jenkins/agent.pp
@@ -47,6 +47,7 @@ class jenkins_demo::profile::jenkins::agent(
   class { 'jenkins::slave':
     masterurl    => 'http://jenkins-master:8080',
     slave_name   => $::hostname,
+    slave_home   => '/j',
     slave_groups => $docker,
     slave_mode   => $slave_mode,
     executors    => $executors,


### PR DESCRIPTION
To reduce overall path lengths, which is a concern due to the 127 char shebang
length limit.